### PR TITLE
Bump versions

### DIFF
--- a/example/linux/flutter/generated_plugin_registrant.cc
+++ b/example/linux/flutter/generated_plugin_registrant.cc
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #include "generated_plugin_registrant.h"
 
 

--- a/example/linux/flutter/generated_plugin_registrant.h
+++ b/example/linux/flutter/generated_plugin_registrant.h
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #ifndef GENERATED_PLUGIN_REGISTRANT_
 #define GENERATED_PLUGIN_REGISTRANT_
 

--- a/example/linux/flutter/generated_plugins.cmake
+++ b/example/linux/flutter/generated_plugins.cmake
@@ -5,6 +5,9 @@
 list(APPEND FLUTTER_PLUGIN_LIST
 )
 
+list(APPEND FLUTTER_FFI_PLUGIN_LIST
+)
+
 set(PLUGIN_BUNDLED_LIBRARIES)
 
 foreach(plugin ${FLUTTER_PLUGIN_LIST})
@@ -13,3 +16,8 @@ foreach(plugin ${FLUTTER_PLUGIN_LIST})
   list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
   list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
 endforeach(plugin)
+
+foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${ffi_plugin}/linux plugins/${ffi_plugin})
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
+endforeach(ffi_plugin)

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -2,20 +2,20 @@ name: example
 description: A new Flutter project.
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.16.0 <3.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
+  flutter_redux: ">=0.9.0 <1.0.0"
   redux: ">=5.0.0 <6.0.0"
-  flutter_redux: ">=0.8.2 <0.9.0"
 
 dev_dependencies:
-  redux_dev_tools: ">=0.7.0 <0.8.0"
   flutter_redux_dev_tools:
     path: ../
   flutter_test:
     sdk: flutter
+  redux_dev_tools: ">=0.7.0 <1.0.0"
 
 
 # For information on the generic Dart part of this file, see the

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,20 +1,20 @@
 name: flutter_redux_dev_tools
 description: A Time Traveling Redux Debugger for Flutter
-version: 0.5.1
+version: 0.5.2
 homepage: https://github.com/brianegan/flutter_redux_dev_tools
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.16.0 <3.0.0'
 
 dependencies:
-  redux: ">=5.0.0 <6.0.0"
-  redux_dev_tools: ">=0.7.0 <0.8.0"
-  flutter_redux: ">=0.8.2 <0.9.0"
   flutter:
     sdk: flutter
+  flutter_redux: ">=0.9.0 <1.0.0"
+  redux: ">=5.0.0 <6.0.0"
+  redux_dev_tools: ">=0.7.0 <1.0.0"
 
 dev_dependencies:
-  pedantic: 1.11.0
   flutter_test:
     sdk: flutter
+  pedantic: 1.11.0
 


### PR DESCRIPTION
Trying to use this package currently requires that we override dependencies on flutter redux. This proposes that the versions be bumped to the current and opened to the next major version. 

Changes with questions:
- Bump in minimum Dart version.

Reason:
![image](https://user-images.githubusercontent.com/29546913/165427060-456e6fba-af69-45ce-a438-a5a108efc281.png)
